### PR TITLE
Fix work flow

### DIFF
--- a/src/components/BookRenderer.tsx
+++ b/src/components/BookRenderer.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { api } from "~/utils/api";
-
-import { useRouter } from "next/router";
 import Link from "next/link";
 
 const BookRenderer = ({ bookId }: { bookId: string }) => {
-  const router = useRouter();
   const { data: book, isLoading } = api.book.getBook.useQuery(bookId);
 
   if (isLoading) return <div>Loading...</div>;

--- a/src/components/BookRenderer.tsx
+++ b/src/components/BookRenderer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { api } from "~/utils/api";
 
 import { useRouter } from "next/router";
+import Link from "next/link";
 
 const BookRenderer = ({ bookId }: { bookId: string }) => {
   const router = useRouter();
@@ -29,18 +30,14 @@ const BookRenderer = ({ bookId }: { bookId: string }) => {
                 {chapter.sections &&
                   chapter.sections.length > 0 &&
                   chapter.sections.map((section, sectionIndex) => (
-                    <a
+                    <Link
                       key={sectionIndex}
-                      onClick={() =>
-                        router.push(
-                          `/book/${bookId}/${chapter.id}/${section.id}`,
-                        )
-                      }
+                      href={`/book/${bookId}/${chapter.id}/${section.id}`}
                       className="font-inter m-0 box-border flex w-full cursor-pointer flex-row items-center border-b border-gray-300 px-3 py-2 text-sm text-black no-underline first:rounded-t-xl last:rounded-b-xl last:border-none hover:bg-gray-50 active:bg-gray-100"
                     >
                       <div className="clear-button-styles mr-4 rounded-full border border-solid border-gray-300 p-0"></div>
                       {section.title}
-                    </a>
+                    </Link>
                   ))}
               </div>
             </div>

--- a/src/components/ChapterUpdate.tsx
+++ b/src/components/ChapterUpdate.tsx
@@ -4,7 +4,6 @@ import * as z from "zod";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "@/components/ui/button";
 import { api } from "~/utils/api";
-
 import React from "react";
 import Link from "next/link";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";

--- a/src/components/SectionUpdate.tsx
+++ b/src/components/SectionUpdate.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
 import { api } from "~/utils/api";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-
+import router from "next/router";
 interface SectionUpdateProps {
   bookId: string;
   chapterId: string;
@@ -57,6 +57,9 @@ const SectionUpdate = ({
     onSuccess: (responseData) => {
       if (responseData && "id" in responseData) {
         void refetchBook();
+        if (router.asPath === `/book/${bookId}/${chapterId}/${sectionId}`) {
+          void router.push(`/book/${bookId}/${chapterId}/addSection`);
+        }
       }
     },
   });

--- a/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
+++ b/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
@@ -25,7 +25,8 @@ export default function ShowSectionPage() {
   if (!retrievedBook) return <p>No book found!</p>;
   if (!chapter) return <p>No chapter found!</p>;
   if (isLoading) return <p>Loading sections...</p>;
-
+  const section = sections.find((s) => s.id === sectionId);
+  if (!section) return <p>No section found!</p>;
   return (
     <>
       <Head>
@@ -41,17 +42,14 @@ export default function ShowSectionPage() {
         </div>
         <div className="flex w-full">
           <div className="w-1/2">
-            {sections.map((section) => (
-              <SectionUpdate
-                key={section.id}
-                bookId={bookId}
-                chapterId={chapterId}
-                initialTitle={section.title}
-                sectionId={section.id}
-                initialContent={section.content}
-              />
-            ))}
-            <SectionForm bookId={bookId} chapterId={chapterId} />
+            <SectionUpdate
+              key={section.id}
+              bookId={bookId}
+              chapterId={chapterId}
+              initialTitle={section.title}
+              sectionId={section.id}
+              initialContent={section.content}
+            />
           </div>
           <div className="w-1/2">
             <SectionRenderer


### PR DESCRIPTION
A couple of edits from yesterday. Needed to turn the bookRenderer's anchor into a next/link. Made it so the [sectionid] index only has a single update component on the left side. When this update compoenent gets deleted the user gets sent back to add section.
<img width="1250" alt="Screenshot 2024-04-17 at 2 10 49 PM" src="https://github.com/gcater/bookwyrm/assets/109175497/434d70c4-2186-49f7-81f5-6a2dcedb8d1f">
