### PR TITLE
Progress Bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-progress": "^1.0.3",
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   '@radix-ui/react-popover':
     specifier: ^1.0.7
     version: 1.0.7(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-progress':
+    specifier: ^1.0.3
+    version: 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-radio-group':
     specifier: ^1.1.3
     version: 1.1.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
@@ -1294,6 +1297,28 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.4
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-progress@1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5G6Om/tYSxjSeEdrb1VfKkfZfn/1IlPWd731h2RfPuSbIfNUgfqAwbKfJCg/PP6nuUCTrYzalwHSpSinoWoCag==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25
       react: 18.2.0

--- a/src/components/DropDownBookButton 2.tsx
+++ b/src/components/DropDownBookButton 2.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import Link from "next/link";
+import { api } from "~/utils/api";
+const DropBookButton = ({ bookId }: { bookId: string }) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const { data: book } = api.book.getBook.useQuery(bookId);
+  if (!book) return <div>No book found</div>;
+  const toggleDropdown = () => setIsDropdownOpen(!isDropdownOpen);
+  return (
+    <div className="absolute right-4 top-[10px]">
+      <div
+        className="svg-container cursor-pointer" 
+        onClick={toggleDropdown}
+        style={{ display: "inline-block", lineHeight: 0 }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="50"
+          height="50"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth=".5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="lucide lucide-circle-ellipsis"
+          onClick={toggleDropdown}
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            fill="var(--circle-fill-color)"
+            stroke="#D1D5DB"
+            />
+            <circle cx="9" cy="9" r=".25" fill="black" />
+            <line x1="11" y1="9" x2="15" y2="9" strokeWidth=".7" />
+            <circle cx="9" cy="12" r=".25" fill="black" />
+            <line x1="11" y1="12" x2="15" y2="12" strokeWidth=".7" />
+            <circle cx="9" cy="15" r=".25" fill="black" />
+            <line x1="11" y1="15" x2="15" y2="15" strokeWidth=".7" />
+          
+        </svg>
+      </div>
+
+      <div
+        className={`fixed right-4 top-[calc(3rem+21px)] flex items-center ${isDropdownOpen ? "" : "hidden"}`}
+      >
+        <div className="box-content h-auto w-96 max-w-xl overflow-y-auto rounded-xl border border-gray-400 bg-white">
+          
+          <div className="w-full">
+            <div className="pt-2 px-4 font-bold text-lg font-serif">{book.title}</div>
+            <div className="pb-2 px-4 text-md text-gray-500 font-serif">{book.author}</div>
+            <div className="py-2.5 px-5 font-serif w-full border-gray-300 border-t">
+              <Link href={`/book/${bookId}`}>Home</Link>
+            </div>
+            {book.chapters &&
+              book.chapters.length > 0 &&
+              book.chapters.map((chapter, chapterIndex) => (
+                <div
+                  key={chapterIndex}
+                  className="w-full border-gray-300 border-t"
+                >
+                  <Link
+                    href={`/book/${bookId}/${chapter.id}/${chapter?.sections?.[0]?.id}`}
+                  >
+                    <div></div>
+                    <div className="py-4 px-5 text-lg font-bold font-serif">{`${chapterIndex + 1}. ${chapter.title}`}</div>
+                  </Link>
+                  {chapter.sections && chapter.sections.length > 0 && (
+                    <div className="flex w-full flex-col">
+                      {chapter.sections.map((section, sectionIndex) => (
+                        <div
+                          key={sectionIndex}
+                          className="w-full border-t border-gray-300"
+                        >
+                          <div className="hover:bg-gray-50">
+                            <Link
+                              href={`/book/${bookId}/${chapter.id}/${section.id}`}
+                              className="cursor-pointer text-black"
+                            >
+                              <div className="py-2.5">
+                                <div className="px-5 font-serif">{section.title}</div>
+                              </div>
+                            </Link>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default DropBookButton;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -4,12 +4,20 @@ import { Progress } from "@/components/ui/progress";
 import Link from "next/link";
 import { api } from "~/utils/api";
 
-const ProgressBar = ({ bookId, sectionId }: { bookId: string; sectionId: string }) => {
+const ProgressBar = ({ bookId, chapterId,sectionId }: { bookId: string; chapterId: string; sectionId: string }) => {
   const { data: retrievedBook } = api.book.getBook.useQuery(bookId);
 
   if (!retrievedBook) return <p>No book found!</p>;
 
-  // Assuming retrievedBook has a structure like { chapters: [{ id: string, sections: [{ id: string }] }] }
+  const currentChapterIndex = retrievedBook.chapters.findIndex(chapter => chapter.id === chapterId);
+  const currentChapterTitle = retrievedBook.chapters[currentChapterIndex]?.title || 'Unknown Chapter';
+  const currentChapter = retrievedBook.chapters[currentChapterIndex];
+  const currentSectionIndex = currentChapter?.sections.findIndex(section => section.id === sectionId) ?? -1;
+  const currentSectionTitle = currentChapter?.sections[currentSectionIndex]?.title || 'Unknown Section';
+
+
+
+
   const calculateProgress = (chapterIndex: number) => {
     if (chapterIndex >= retrievedBook.chapters.length) return 0; // Ensure chapterIndex is within bounds
     const currentChapter = retrievedBook.chapters[chapterIndex];
@@ -27,18 +35,22 @@ const ProgressBar = ({ bookId, sectionId }: { bookId: string; sectionId: string 
   const totalSections = retrievedBook.chapters.reduce((acc, chapter) => acc + chapter.sections.length, 0);
 
   return (
-    <div className="flex gap-2 max-w-[700px] mx-auto pb-3 mt-[-15px]">
-       {retrievedBook.chapters.map((chapter, index) => {
-        if (chapter.sections.length === 0) return null; // Skip chapters with no sections
-        const chapterWidth = (chapter.sections.length / totalSections) * 100;
-        return (
-          <div key={chapter.id} className="flex justify-center relative" style={{ width: `${chapterWidth}%` }}>
-              <Progress  className= "h-1" value={calculateProgress(index)} max={100} />
-          </div> 
-        );
-       })} 
+    <div className="font-serif">
+      <div className="text-center font-bold text-xs text-black pb-10 mt-[-60px]">{`${currentChapterTitle}`}</div>
+      <div className="text-center text-xs text-gray-600 pb-10 mt-[-40px]">{`${currentSectionTitle}`}</div>
+      <div className="flex gap-2 max-w-[700px] mx-auto pb-3 mt-[-28px]">
+          
+         {retrievedBook.chapters.map((chapter, index) => {
+          if (chapter.sections.length === 0) return null; // Skip chapters with no sections
+          const chapterWidth = (chapter.sections.length / totalSections) * 100;
+          return (
+            <div key={chapter.id} className="flex justify-center relative" style={{ width: `${chapterWidth}%` }}>
+                <Progress  className= "h-1 bg-gray-300" value={calculateProgress(index)} max={100} />
+            </div> 
+          );
+         })} 
+      </div>
     </div>
   );
 };
-
 export default ProgressBar;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import DropDownBookButton from "./DropDownBookButton";
+import { Progress } from "@/components/ui/progress";
+import Link from "next/link";
+import { api } from "~/utils/api";
+
+const ProgressBar = ({ bookId, sectionId }: { bookId: string; sectionId: string }) => {
+  const { data: retrievedBook } = api.book.getBook.useQuery(bookId);
+
+  if (!retrievedBook) return <p>No book found!</p>;
+
+  // Assuming retrievedBook has a structure like { chapters: [{ id: string, sections: [{ id: string }] }] }
+  const calculateProgress = (chapterIndex: number) => {
+    if (chapterIndex >= retrievedBook.chapters.length) return 0; // Ensure chapterIndex is within bounds
+    const currentChapter = retrievedBook.chapters[chapterIndex];
+    if (!currentChapter) return 0; // Handle undefined currentChapter
+
+    const sectionIndex = currentChapter.sections.findIndex(section => section.id === sectionId);
+    // If the current chapter is past, return 100%
+    if (chapterIndex < retrievedBook.chapters.findIndex(chapter => chapter.sections.some(section => section.id === sectionId))) {
+      return 100;
+    }
+    // Calculate progress based on the section index
+    return sectionIndex >= 0 ? (sectionIndex + 1) / currentChapter.sections.length * 100 : 0;
+  };
+
+  return (
+    <div className="flex gap-2 w-full">
+       {retrievedBook.chapters.map((chapter, index) => {
+        const chapterWidth = 100 / retrievedBook.chapters.length;
+        return (
+          <div key={chapter.id} className="flex justify-center relative" style={{ width: `${chapterWidth}%` }}>
+              <Progress value={calculateProgress(index)} max={100} />
+          </div> 
+        );
+       })} 
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import DropDownBookButton from "./DropDownBookButton";
 import { Progress } from "@/components/ui/progress";
-import Link from "next/link";
 import { api } from "~/utils/api";
 
 const ProgressBar = ({ bookId, chapterId,sectionId }: { bookId: string; chapterId: string; sectionId: string }) => {
@@ -10,13 +8,10 @@ const ProgressBar = ({ bookId, chapterId,sectionId }: { bookId: string; chapterI
   if (!retrievedBook) return <p>No book found!</p>;
 
   const currentChapterIndex = retrievedBook.chapters.findIndex(chapter => chapter.id === chapterId);
-  const currentChapterTitle = retrievedBook.chapters[currentChapterIndex]?.title || 'Unknown Chapter';
+  const currentChapterTitle = retrievedBook.chapters[currentChapterIndex]?.title ?? 'Unknown Chapter';
   const currentChapter = retrievedBook.chapters[currentChapterIndex];
   const currentSectionIndex = currentChapter?.sections.findIndex(section => section.id === sectionId) ?? -1;
-  const currentSectionTitle = currentChapter?.sections[currentSectionIndex]?.title || 'Unknown Section';
-
-
-
+  const currentSectionTitle = currentChapter?.sections[currentSectionIndex]?.title ?? 'Unknown Section';
 
   const calculateProgress = (chapterIndex: number) => {
     if (chapterIndex >= retrievedBook.chapters.length) return 0; // Ensure chapterIndex is within bounds
@@ -24,11 +19,9 @@ const ProgressBar = ({ bookId, chapterId,sectionId }: { bookId: string; chapterI
     if (!currentChapter || currentChapter.sections.length === 0) return 0; // Handle undefined currentChapter or chapters with no sections
 
     const sectionIndex = currentChapter.sections.findIndex(section => section.id === sectionId);
-    // If the current chapter is past, return 100%
     if (chapterIndex < retrievedBook.chapters.findIndex(chapter => chapter.sections.some(section => section.id === sectionId))) {
       return 100;
     }
-    // Calculate progress based on the section index
     return sectionIndex >= 0 ? (sectionIndex) / currentChapter.sections.length * 100 : 0;
   };
 
@@ -41,7 +34,7 @@ const ProgressBar = ({ bookId, chapterId,sectionId }: { bookId: string; chapterI
       <div className="flex gap-2 max-w-[700px] mx-auto pb-3 mt-[-28px]">
           
          {retrievedBook.chapters.map((chapter, index) => {
-          if (chapter.sections.length === 0) return null; // Skip chapters with no sections
+          if (chapter.sections.length === 0) return null; 
           const chapterWidth = (chapter.sections.length / totalSections) * 100;
           return (
             <div key={chapter.id} className="flex justify-center relative" style={{ width: `${chapterWidth}%` }}>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -13,7 +13,7 @@ const ProgressBar = ({ bookId, sectionId }: { bookId: string; sectionId: string 
   const calculateProgress = (chapterIndex: number) => {
     if (chapterIndex >= retrievedBook.chapters.length) return 0; // Ensure chapterIndex is within bounds
     const currentChapter = retrievedBook.chapters[chapterIndex];
-    if (!currentChapter) return 0; // Handle undefined currentChapter
+    if (!currentChapter || currentChapter.sections.length === 0) return 0; // Handle undefined currentChapter or chapters with no sections
 
     const sectionIndex = currentChapter.sections.findIndex(section => section.id === sectionId);
     // If the current chapter is past, return 100%
@@ -24,13 +24,16 @@ const ProgressBar = ({ bookId, sectionId }: { bookId: string; sectionId: string 
     return sectionIndex >= 0 ? (sectionIndex + 1) / currentChapter.sections.length * 100 : 0;
   };
 
+  const totalSections = retrievedBook.chapters.reduce((acc, chapter) => acc + chapter.sections.length, 0);
+
   return (
-    <div className="flex gap-2 w-full">
+    <div className="flex gap-2 max-w-[700px] mx-auto pb-3 mt-[-15px]">
        {retrievedBook.chapters.map((chapter, index) => {
-        const chapterWidth = 100 / retrievedBook.chapters.length;
+        if (chapter.sections.length === 0) return null; // Skip chapters with no sections
+        const chapterWidth = (chapter.sections.length / totalSections) * 100;
         return (
           <div key={chapter.id} className="flex justify-center relative" style={{ width: `${chapterWidth}%` }}>
-              <Progress value={calculateProgress(index)} max={100} />
+              <Progress  className= "h-1" value={calculateProgress(index)} max={100} />
           </div> 
         );
        })} 

--- a/src/components/SectionBanner.tsx
+++ b/src/components/SectionBanner.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import DropDownBookButton from "./DropDownBookButton";
-import { Progress } from "@/components/ui/progress"
+import ProgressBar from "./ProgressBar"
 import Link from "next/link";
 import { api } from "~/utils/api";
-const SectionBanner = ({ bookId }: { bookId: string }) => {
+const SectionBanner = ({ bookId,sectionId }: { bookId: string,sectionId:string }) => {
     const { data: retrievedBook } = api.book.getBook.useQuery(bookId);
     if (!retrievedBook) return <p>No book found!</p>;
   return (
@@ -12,16 +12,7 @@ const SectionBanner = ({ bookId }: { bookId: string }) => {
         <h1 className="relative top-[-5px] text-2xl font-bold text-gray-700">
           <Link href={`/book/${bookId}`}>BookWyrm</Link>
         </h1>
-        <div className="flex justify-center relative -top-7 max-w-[500px] mx-auto">
-          <div className="flex w-full justify-between">
-            <div className="w-1/2">
-              <Progress/>
-            </div>
-            <div className="w-1/2">
-              <Progress/>
-            </div>
-          </div>
-        </div>
+        <ProgressBar bookId={bookId}/> 
         <div className="flex w-full justify-end">
           <DropDownBookButton bookId={bookId} />
         </div>

--- a/src/components/SectionBanner.tsx
+++ b/src/components/SectionBanner.tsx
@@ -12,7 +12,7 @@ const SectionBanner = ({ bookId,sectionId }: { bookId: string,sectionId:string }
         <h1 className="relative top-[-5px] text-2xl font-bold text-gray-700">
           <Link href={`/book/${bookId}`}>BookWyrm</Link>
         </h1>
-        <ProgressBar bookId={bookId}/> 
+        <ProgressBar bookId={bookId} sectionId={sectionId}/> 
         <div className="flex w-full justify-end">
           <DropDownBookButton bookId={bookId} />
         </div>

--- a/src/components/SectionBanner.tsx
+++ b/src/components/SectionBanner.tsx
@@ -3,7 +3,7 @@ import DropDownBookButton from "./DropDownBookButton";
 import ProgressBar from "./ProgressBar"
 import Link from "next/link";
 import { api } from "~/utils/api";
-const SectionBanner = ({ bookId,sectionId }: { bookId: string,sectionId:string }) => {
+const SectionBanner = ({ bookId, chapterId, sectionId }: { bookId: string, chapterId:string, sectionId:string }) => {
     const { data: retrievedBook } = api.book.getBook.useQuery(bookId);
     if (!retrievedBook) return <p>No book found!</p>;
   return (
@@ -12,7 +12,7 @@ const SectionBanner = ({ bookId,sectionId }: { bookId: string,sectionId:string }
         <h1 className="relative top-[-5px] text-2xl font-bold text-gray-700">
           <Link href={`/book/${bookId}`}>BookWyrm</Link>
         </h1>
-        <ProgressBar bookId={bookId} sectionId={sectionId}/> 
+        <ProgressBar bookId={bookId} chapterId={chapterId} sectionId={sectionId}/> 
         <div className="flex w-full justify-end">
           <DropDownBookButton bookId={bookId} />
         </div>

--- a/src/components/SectionBanner.tsx
+++ b/src/components/SectionBanner.tsx
@@ -1,13 +1,27 @@
 import React from "react";
 import DropDownBookButton from "./DropDownBookButton";
+import { Progress } from "@/components/ui/progress"
 import Link from "next/link";
+import { api } from "~/utils/api";
 const SectionBanner = ({ bookId }: { bookId: string }) => {
+    const { data: retrievedBook } = api.book.getBook.useQuery(bookId);
+    if (!retrievedBook) return <p>No book found!</p>;
   return (
-    <div className="fixed flex  w-full flex-col">
+    <div className="fixed flex w-full flex-col">
       <header className=" border-b border-gray-300 bg-white px-4 pt-[25px]">
         <h1 className="relative top-[-5px] text-2xl font-bold text-gray-700">
           <Link href={`/book/${bookId}`}>BookWyrm</Link>
         </h1>
+        <div className="flex justify-center relative -top-7 max-w-[500px] mx-auto">
+          <div className="flex w-full justify-between">
+            <div className="w-1/2">
+              <Progress/>
+            </div>
+            <div className="w-1/2">
+              <Progress/>
+            </div>
+          </div>
+        </div>
         <div className="flex w-full justify-end">
           <DropDownBookButton bookId={bookId} />
         </div>

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "~/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -17,7 +17,7 @@ const Progress = React.forwardRef<
   >
     <ProgressPrimitive.Indicator
       className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
     />
   </ProgressPrimitive.Root>
 ))

--- a/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
+++ b/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
@@ -37,7 +37,7 @@ export default function ShowSectionPage() {
           content="Edit sections of your book chapter."
         />
       </Head>
-      <SectionBanner bookId={bookId} />
+      <SectionBanner bookId={bookId} sectionId={sectionId} />
       <main className="flex min-h-screen flex-col items-center justify-center">
         <div className="container flex w-full flex-col items-center justify-center gap-12 px-4 py-16">
           <div className="flex w-full flex-col items-center gap-2"></div>

--- a/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
+++ b/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
@@ -37,7 +37,7 @@ export default function ShowSectionPage() {
           content="Edit sections of your book chapter."
         />
       </Head>
-      <SectionBanner bookId={bookId} sectionId={sectionId} />
+      <SectionBanner bookId={bookId} chapterId={chapterId} sectionId={sectionId} />
       <main className="flex min-h-screen flex-col items-center justify-center">
         <div className="container flex w-full flex-col items-center justify-center gap-12 px-4 py-16">
           <div className="flex w-full flex-col items-center gap-2"></div>

--- a/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
+++ b/src/pages/book/[bookid]/[chapterid]/[sectionid]/index.tsx
@@ -2,7 +2,6 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
 import SectionBanner from "~/components/SectionBanner";
-import SectionForm from "~/components/SectionForm";
 import SectionRenderer from "~/components/SectionRenderer";
 import SectionUpdate from "~/components/SectionUpdate";
 import { api } from "~/utils/api";

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -112,3 +112,7 @@ h6 {
 .svg-container:hover {
   --circle-fill-color: #F7FAFC; /* Change to grey on hover */
 }
+
+.small-progress {
+  width: 50%;
+}


### PR DESCRIPTION
https://www.loom.com/share/e48d2c3aebc9462f9e3ed53d89918634?sid=cfcc19ff-6de4-4fea-80b1-2cf490f03ced

<img width="1894" alt="Screenshot 2024-04-18 at 4 00 01 PM" src="https://github.com/gcater/bookwyrm/assets/109175497/665ee62d-93ee-4f7d-8ff0-2397729676c3">
<img width="1899" alt="Screenshot 2024-04-18 at 4 00 11 PM" src="https://github.com/gcater/bookwyrm/assets/109175497/ec02e5cf-f2ea-47e1-bb7e-eadf466ab865">

Adding Progress Bar to the section index. When the window changes the spacing does not change the same way Network state does. When a user scrolls down a section in Network State the progress bar moves along as well. Need to implement this functionality.